### PR TITLE
change docker image

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM pangeo/base-image:2020.03.27
+FROM pangeo/pangeo-notebook:2020.03.27

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,7 +1,0 @@
-name: pangeo
-channels:
-  - conda-forge
-dependencies:
-  - pangeo-notebook==2020.03.27
-  - git
-  - nbgitpuller

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,6 +2,4 @@
 set -euo pipefail
 
 # labextensions
-jupyter labextension install --clean dask-labextension \
-                             @jupyter-widgets/jupyterlab-manager
 jupyter serverextension enable --py nbgitpuller --sys-prefix


### PR DESCRIPTION
Use the more full-featured image.

Hopefully the post-build from that image carries over to this one:
https://github.com/pangeo-data/pangeo-stacks-dev/blob/2020.03.28/pangeo-notebook/postBuild