### PR TITLE
bump pangeo-notebook

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ channels:
  - conda-forge
 dependencies:
  - python=3.7*
- - pangeo-notebook=2020.05.10
+ - pangeo-notebook=2020.08.31
  - pip=20
  - cartopy
  - dask-ml


### PR DESCRIPTION
In preparation for an update to the pangeo binder to dask-gateway 0.8.0, we need to update dask-gateway in the client images (https://github.com/pangeo-data/pangeo-binder/pull/159)