### PR TITLE
Docs on updating pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,32 @@ on the binder.pangeo.io binder with the ``2020.10.10`` version of this image.
 
 https://binder.pangeo.io/v2/gh/pangeo-gallery/default-binder/2020.10.10/?urlpath=git-pull?repo=https://github.com/pangeo-gallery/example-gallery%26amp%3Burlpath=lab/tree/example-gallery
 
-## Releasing
+## Pinning
 
 We strongly recommend using a specific tagged version of the images here,
 rather than just pointing to ``master``.
 https://github.com/pangeo-gallery/default-binder/tags has a list of the tags.
 This ensures that updates to the image don't unexpectedly break your notebooks.
 
+## Updating versions
+
+Suppose you've made an update to your gallery content that relies on a feature from
+a new package or an updated version of the package.
+
+If `pangeo-gallery/default-binder` already has a [tag](https://github.com/pangeo-gallery/default-binder/tags)
+with the versions you need, you can just update the `binder_ref` value in your `binder-gallery.yaml`. For
+example, change `binder_ref: 2020.10.10` to `binder_ref: 2020.10.27` in https://github.com/rsignell-usgs/esip-gallery/blob/aaef02335bbea0cf3ddaccf82f482a0e0af11339/binder-gallery.yaml#L8.
+
+If there isn't a tag available yet, you can ask the pangeo-gallery maintainers to make one.
+There may be a pull request from Dependabot updating the image, or we can manually trigger
+an update from https://github.com/pangeo-gallery/default-binder/network/updates. To make a
+release, a maintainer will push a tag.
+
+```
+git checkout master
+git pull
+git tag -a <date-of-image> -m "<date-of-image>"
+git push upstream master --follow-tags
+```
+
+And now you can update your `binder_ref` as described above.


### PR DESCRIPTION
This documents the process we went through to update the environments for @rsignell-usgs


1. Added a package to pangeo-data/docker-images
2. Pushed a tag to pangeo-data/docker-images
3. Merged #13 from dependabot updating the image here.
4. Pushed a tag here (manually). This should maybe be automated.
5. Rich updates his `binder_ref` to point to the new tag in default-binder.

One point I'm not clear on: what triggers a rebuild on https://github.com/pangeo-gallery/pangeo-gallery /  http://gallery.pangeo.io, such that the new content / new environment would be reflected there?